### PR TITLE
fix eval errors caused by self-join queries and text-type numbers

### DIFF
--- a/data/DB_DBcontent_equivalence/gold_post_perturbation.sql
+++ b/data/DB_DBcontent_equivalence/gold_post_perturbation.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d35e35da171b51567c148609ade33b3db369d28ed718736f925d03628b084a9
-size 69112
+oid sha256:4a7c8161535b6bcd831701f50b5cbf89f74a5e87a0d90b24dff20cbe84a8422a
+size 69050

--- a/data/DB_DBcontent_equivalence/questions_post_perturbation.json
+++ b/data/DB_DBcontent_equivalence/questions_post_perturbation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51cedb956976897c5312193524199bee814844d5cf03f3b69d7fef95218c47d9
-size 1399911
+oid sha256:1e81b57f3c4a0c6e02282402a7c570a6fdbd2e1fd8c80dca30b7b3bfd4423fc1
+size 1425511

--- a/data/DB_schema_abbreviation/gold_post_perturbation.sql
+++ b/data/DB_schema_abbreviation/gold_post_perturbation.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:005e5d897315dffc0434ddbb4e5dd81f1654eb99f6a14d36c0c94d932585c167
-size 419289
+oid sha256:ca512add42d4cb8324943692649bc4c2333af0a0594e6f8db66b917467445e0c
+size 419297

--- a/data/DB_schema_abbreviation/gold_post_perturbation.sql
+++ b/data/DB_schema_abbreviation/gold_post_perturbation.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f0705c49a1329a2a964ea34d0bf00ea4bc5d2c4b18c72f0f2bc68bca803e999
-size 420725
+oid sha256:005e5d897315dffc0434ddbb4e5dd81f1654eb99f6a14d36c0c94d932585c167
+size 419289

--- a/data/DB_schema_abbreviation/questions_post_perturbation.json
+++ b/data/DB_schema_abbreviation/questions_post_perturbation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82915e819a5ea1de4aaf7112f02456f0347f73a978d89b2a2733c3fabd7144ba
-size 9401743
+oid sha256:f3a4a8b0e8b1673f5d89f9de10ab87f7c5f33b19877e4e9df9d6b9a9116c0386
+size 9400491

--- a/data/DB_schema_abbreviation/questions_post_perturbation.json
+++ b/data/DB_schema_abbreviation/questions_post_perturbation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3a4a8b0e8b1673f5d89f9de10ab87f7c5f33b19877e4e9df9d6b9a9116c0386
-size 9400491
+oid sha256:35adde1ad5e1b2b312667ce35a429e6b4e4c72667e4f3f64734d465ff73a48e0
+size 9400507

--- a/data/DB_schema_synonym/database_post_perturbation/student_transcripts_tracking_3/schema_3.sql
+++ b/data/DB_schema_synonym/database_post_perturbation/student_transcripts_tracking_3/schema_3.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96bb07fcd4fec9e0598e664292e7465fa0fc443b5d168fd5eebe44759861b25b
-size 16041
+oid sha256:ba75b8e9dc2bc0b11547969103f4e64de6b3fa719d861752242ff29c538c00d6
+size 16048

--- a/data/DB_schema_synonym/database_post_perturbation/student_transcripts_tracking_3/student_transcripts_tracking_3.sqlite
+++ b/data/DB_schema_synonym/database_post_perturbation/student_transcripts_tracking_3/student_transcripts_tracking_3.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56b54b39617bb951f0c528a70b680665ecf7994012c2820b0b712bbfd9a8db4c
+oid sha256:29eb84e135c0912f224f5a991edaa8ea7929030f5382df2e6d48fe9d18099f00
 size 49152

--- a/data/DB_schema_synonym/gold_post_perturbation.sql
+++ b/data/DB_schema_synonym/gold_post_perturbation.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c232824ecaebd426d43b7724a6c2e596fd42ef0b7b032934e76b8b204938fe5
-size 415715
+oid sha256:85a0e3f94b6129476a22ca89e2997aacee9c2da92dcf15613c0f547fd141ee1a
+size 414581

--- a/data/DB_schema_synonym/questions_post_perturbation.json
+++ b/data/DB_schema_synonym/questions_post_perturbation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ee201db601f78492f4320dad288541ea1a506a615eddaad0f41e0d622df3aaf
-size 8840832
+oid sha256:7b5cdef840c439dba65cfb18fb7289428985b1e6b9a7371891f5ae3c21e1db01
+size 8839104

--- a/data/DB_schema_synonym/tables_post_perturbation.json
+++ b/data/DB_schema_synonym/tables_post_perturbation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a33277078d66703402654cc952fa45f1b2cc1894b626ae29a7f98c239276e00
-size 462534
+oid sha256:3ced8e464806a6f98135c7f3544aabde087fc338b8da46cf46154e2cb98daf7c
+size 462548


### PR DESCRIPTION
## Fix issue [#1](https://github.com/awslabs/diagnostic-robustness-text-to-sql/issues/1) 

1. Table aliases have been added to the self-join queries. This implementation was ad hoc since only three queries in Spider-dev had self-joins. However, it should be incorporated into the SQL parser in the future.

2. Integer-value floats, such as 100.0, have been converted to integers, for example, 100. This has been done to ensure consistency in data types.
